### PR TITLE
use gcompat to run ghr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.14 as base
 
-RUN apk add --no-cache jq curl
+RUN apk add --no-cache jq curl gcompat
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN curl -s https://api.github.com/repos/tcnksm/ghr/releases/latest | \


### PR DESCRIPTION
The latest release of ghr is dynamically linked against libc, but alpine linux has a minimal libc which prevents ghr from running. The fix is to use gcompat as a compatibility layer so that glibc apis can be used.